### PR TITLE
query factory 적용 예시

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.13.5",
         "@emotion/styled": "^11.13.5",
+        "@lukemorales/query-key-factory": "^1.3.4",
         "@tanstack/react-query": "^5.61.0",
         "axios": "^1.7.7",
         "moment": "^2.30.1",
@@ -1253,6 +1254,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lukemorales/query-key-factory": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@lukemorales/query-key-factory/-/query-key-factory-1.3.4.tgz",
+      "integrity": "sha512-A3frRDdkmaNNQi6mxIshsDk4chRXWoXa05US8fBo4kci/H+lVmujS6QrwQLLGIkNIRFGjMqp2uKjC4XsLdydRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@tanstack/query-core": ">= 4.0.0",
+        "@tanstack/react-query": ">= 4.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@emotion/react": "^11.13.5",
     "@emotion/styled": "^11.13.5",
+    "@lukemorales/query-key-factory": "^1.3.4",
     "@tanstack/react-query": "^5.61.0",
     "axios": "^1.7.7",
     "moment": "^2.30.1",

--- a/src/entities/community/api/SearchListGet.ts
+++ b/src/entities/community/api/SearchListGet.ts
@@ -1,8 +1,14 @@
 import URL from 'shared/config/urls';
 import axiosInstance from 'shared/lib/axiosInstance';
 
+export interface FetchGetSearchListRequestDto {
+  option: string;
+  page: number;
+  keyword: string;
+}
+
 // 메인데이터 호출
-export const fetchGetSearchList = async (option: string, page: number, keyword: string) => {
+export const fetchGetSearchList = async ({ option, page, keyword }: FetchGetSearchListRequestDto) => {
   const response = await axiosInstance({
     method: 'GET',
     url: URL.SERVERURL + URL.API.LISTSEARCH,

--- a/src/entities/community/api/community.query.ts
+++ b/src/entities/community/api/community.query.ts
@@ -1,0 +1,17 @@
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+
+import { fetchGetPageList } from './PageListGet';
+import { fetchGetSearchList, FetchGetSearchListRequestDto } from './SearchListGet';
+
+type CommunityFilters = FetchGetSearchListRequestDto;
+
+export const community = createQueryKeys('community', {
+  list: (page: number) => ({
+    queryKey: [{ page }],
+    queryFn: () => fetchGetPageList(page),
+  }),
+  filter: (filters: CommunityFilters) => ({
+    queryKey: [{ ...filters }],
+    queryFn: () => fetchGetSearchList(filters),
+  }),
+});

--- a/src/features/community/list/lib/useGetPageListQuery.ts
+++ b/src/features/community/list/lib/useGetPageListQuery.ts
@@ -1,14 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { fetchGetPageList } from 'entities/community/api/PageListGet';
+import { community } from 'entities/community/api/community.query';
 
 function useGetPageListQuery(page?: number, queryConfig = {}) {
-  const { data, error, isLoading } = useQuery({
-    queryKey: ['pageList', page],
-    queryFn: () => (page ? fetchGetPageList(page) : Promise.resolve(null)),
-    retry: 3,
-    ...queryConfig,
-  });
+  const { data, error, isLoading } = useQuery({ ...community.list(page || 1), retry: 3, ...queryConfig });
 
   return { data, isLoading, error };
 }

--- a/src/features/community/list/lib/useGetSearchListQuery.ts
+++ b/src/features/community/list/lib/useGetSearchListQuery.ts
@@ -1,18 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { fetchGetSearchList } from 'entities/community/api/SearchListGet';
+import { community } from 'entities/community/api/community.query';
 
 function useGetSearchListQuery(option: string, page: number, keyword: string, queryConfig = {}) {
-  const queryKey = [
-    'SearchList',
-    {
-      params: { searchType: option, page: page, keyword: keyword },
-    },
-  ];
-
   const { data, error, isLoading } = useQuery({
-    queryKey,
-    queryFn: () => fetchGetSearchList(option, page, keyword),
+    ...community.filter({ option, page, keyword }),
     retry: 3,
     ...queryConfig,
   });


### PR DESCRIPTION
## 요약
- #71 을 위한 예시 작성
- [query key factory](https://www.npmjs.com/package/@lukemorales/query-key-factory) 패키지 추가 

## 설명

### 예시 코드 
createQueryKeys와 함께 적절한 프로퍼티명(list, detail 등)으로 queryKey와 queryFn을 작성하면 됩니다.
그 외 queryOption은 useQuery사용처에 추가하면 됩니다.
```tsx
// community.query.ts
import { createQueryKeys } from '@lukemorales/query-key-factory';

import { fetchGetPageList } from './PageListGet';
import { fetchGetSearchList, FetchGetSearchListRequestDto } from './SearchListGet';

export const community = createQueryKeys('community', {
  list: (page: number) => ({
    queryKey: [{ page }], // ['community', { page: 1 }] 
    queryFn: () => fetchGetPageList(page),
  }),
  filter: (filters: CommunityFilters) => ({
    queryKey: [{ ...filters }], // ['community, {...filters}]
    queryFn: () => fetchGetSearchList(filters),
  }),
});

// useGetPostListQuery.ts
function useGetPageListQuery(page?: number, queryConfig = {}) {
  const { data, error, isLoading } = useQuery({ ...community.list(page || 1), retry: 3, ...queryConfig });

  return { data, isLoading, error };
}
```

### 코드 선언 위치
코드 선언 위치를 한 번 정리해봤어요! queryKey만 추가했고 나머지는 동일합니다.

1. queryKey 선언 위치: `entities/{entity}/api/{entity}.query.ts` 
2. fetch 함수 선언 위치(동일): `entities/{entitiy}/api`
3. useQuery/useMutation 선언 위치(동일): `{layer}/{domain}/{lib,ui}`


