### PR TITLE
삭제된 게시글 api 404 에러 관련 url 수정 및 불필요한 url 제거

### DIFF
--- a/src/shared/config/urls.ts
+++ b/src/shared/config/urls.ts
@@ -67,8 +67,6 @@ const URL = {
       ADD: 'musing/playlist/addMusicToPlaylist',
       REMOVE: 'musing/playlist/remove',
       MODIFY: 'musing/playlist/modify',
-      REMOVED_BOARD_LIST: 'musing/admin/board/list/removed', // 삭제된 게시글 리스트
-      REMOVED_BOARD_DETAIL: 'musing/admin/board/list/removed/detail', // 삭제된 게시글 상세
     },
 
     TOKENREISSUE: 'musing/auth/reissue', //토큰 재발급

--- a/src/shared/config/urls.ts
+++ b/src/shared/config/urls.ts
@@ -53,7 +53,7 @@ const URL = {
       PERMIT_BOARD: 'musing/admin/board/permit', // 게시글 승인
       REJECT_BOARD: 'musing/admin/board/non/permit', // 게시글 승인 거절
       REMOVED_BOARD_LIST: 'musing/admin/board/list/removed', // 삭제된 게시글 리스트
-      REMOVED_BOARD_DETAIL: 'musing/admin/board/list/removed/detail', // 삭제된 게시글 상세
+      REMOVED_BOARD_DETAIL: 'musing/admin/board/removed', // 삭제된 게시글 상세
     },
 
     // 플레이리스트


### PR DESCRIPTION
f4fe7efdb931816c01a3dbeb8cf022e74e7b7f9a
- 삭제된 게시글 api url 변경

> 디스코드 Post 및 swagger api작성 토대로
> 
> ```
>       REMOVED_BOARD_LIST: 'musing/admin/board/list/removed', // 삭제된 게시글 리스트
>       REMOVED_BOARD_DETAIL: 'musing/admin/board/list/removed/detail', // 삭제된 게시글 상세
> ```
> 로 잘못 작성되어 있던 부분에서
> 
> ```
>       REMOVED_BOARD_LIST: 'musing/admin/board/list/removed', // 삭제된 게시글 리스트
>       REMOVED_BOARD_DETAIL: 'musing/admin/board/removed', // 삭제된 게시글 상세
> ```
> 로 변경하였습니다.
> 


081b30d75b068a640137b7eab8438781cb2a4814
- 플레이리스트 관련 url에 포함되어 있던 삭제된 게시글 관련 api url 제거

> 해당 api url의 함수 선언 위치를 확인하였으나, 사용되는 부분이 없어 제거했습니다.