### PR TITLE
관리자 페이지 및 공지사항 검색란 필터블록 border 제거, 필터블록의 필터명 수정

### DIFF
--- a/src/pages/admin/ui/AdminNotice.tsx
+++ b/src/pages/admin/ui/AdminNotice.tsx
@@ -72,7 +72,7 @@ export const AdminNoticePage = () => {
       <FilterBlock>
         <SearchInputWithFilter
           options={noticeSearchFilterOptions}
-          searchFilterPlaceholder="작성자"
+          searchFilterPlaceholder="제목"
           placeholder="내용을 입력해 주세요."
         />
       </FilterBlock>

--- a/src/pages/notice/ui/Notice.tsx
+++ b/src/pages/notice/ui/Notice.tsx
@@ -72,7 +72,7 @@ export const NoticePage = () => {
       <FilterBlock>
         <SearchInputWithFilter
           options={noticeSearchFilterOptions}
-          searchFilterPlaceholder="작성자"
+          searchFilterPlaceholder="제목"
           placeholder="내용을 입력해 주세요."
         />
       </FilterBlock>

--- a/src/shared/ui/Input/SearchInputWithFilter.tsx
+++ b/src/shared/ui/Input/SearchInputWithFilter.tsx
@@ -88,7 +88,7 @@ const Container = styled.div<{ width: number }>`
   display: flex;
   justify-content: flex-end;
   position: relative;
-  border: 1px solid;
+  border: none;
   width: ${({ width }) => `${width}px`};
 `;
 


### PR DESCRIPTION
- 검색기능의 필터블록을 기준으로 Border가 있던 부분을 제거했습니다.

- 필터블록 내의 '작성자'를 '제목'으로 변경했습니다.
  - api도 제목으로만 연결되어있으며, 공지사항의 경우 작성자 모두 관리자 이기에 배제하였습니다.

> - 수정 전
> ![image](https://github.com/user-attachments/assets/75d3c45a-17e5-4042-9825-8253649e03e8)
> 
> - 수정 후
> ![image](https://github.com/user-attachments/assets/504ede2b-5763-4a81-b800-79dcfde9388c)