### PR TITLE
관리자 승인 툴팁 위치 조정 및 마우스 인식 범위 수정

### DIFF
--- a/src/entities/reply/api/index.ts
+++ b/src/entities/reply/api/index.ts
@@ -9,6 +9,7 @@ export interface FetchGetReplyDto {
   sortType?: SortType;
   sort?: Sort;
   page?: number;
+  size?: number;
 }
 
 interface FetchGetReplyResponse extends Pagination {

--- a/src/entities/reply/ui/DeleteReplyModal.tsx
+++ b/src/entities/reply/ui/DeleteReplyModal.tsx
@@ -1,0 +1,34 @@
+import { ConfirmModal } from 'shared/ui/Modal';
+
+export const DeleteReplyModal = ({
+  open,
+  onClose,
+  onConfirm,
+  hasReview,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  hasReview: boolean;
+}) => {
+  if (hasReview) {
+    return (
+      <ConfirmModal
+        text="작성한 리뷰가 없습니다."
+        confirmText="확인"
+        open={open}
+        onClose={onClose}
+        onConfirm={onClose}
+      />
+    );
+  }
+  return (
+    <ConfirmModal
+      text="정말 리뷰를 삭제 하시겠어요?"
+      confirmText="삭제하기"
+      open={open}
+      onClose={onClose}
+      onConfirm={onConfirm}
+    />
+  );
+};

--- a/src/entities/reply/ui/Reply.tsx
+++ b/src/entities/reply/ui/Reply.tsx
@@ -1,10 +1,9 @@
 import styled from '@emotion/styled';
 import { useState } from 'react';
 
-import { DeleteReviewModal } from 'widgets/ui/PlayList/DeleteReviewModal';
-
 import { ReportButton } from 'entities/community/ui/ReportButton';
 import { Reply as TReply } from 'entities/reply/model/type';
+import { DeleteReplyModal } from 'entities/reply/ui/DeleteReplyModal';
 import { ProfileImage } from 'entities/user/ui/ProfileImage';
 
 import { useUserInfoStore } from 'shared/store/userInfo';
@@ -89,7 +88,7 @@ export const Reply = ({ comments, onDeleteReply, onModifyReply }: ReplyProps) =>
                 )}
               </Box>
             </ReplyBox>
-            <DeleteReviewModal
+            <DeleteReplyModal
               open={!!selectedReplyId}
               onClose={() => setSelectedReplyId(null)}
               onConfirm={() => selectedReplyId && onDeleteReply(Number(selectedReplyId))}

--- a/src/entities/reply/ui/ReplyForm.tsx
+++ b/src/entities/reply/ui/ReplyForm.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 
-import { useMyRepliesQuery, useReplyEditMutation, useReplyWriteMutation } from 'entities/reply/api/reply.queries';
+import { useModifyReplyMutation, useMyRepliesQuery, useReplyWriteMutation } from 'entities/reply/api/reply.queries';
 import { ProfileImage } from 'entities/user/ui/ProfileImage';
 
 import { Button, StarRatingInput, TextArea } from 'shared/ui/';
@@ -14,7 +14,7 @@ export const ReviewForm = ({ boardId }: { boardId: number }) => {
 
   const { data: existingReply } = useMyRepliesQuery(boardId);
   const writeMutation = useReplyWriteMutation(boardId);
-  const editMutation = useReplyEditMutation(boardId);
+  const editMutation = useModifyReplyMutation(boardId);
 
   useEffect(() => {
     if (existingReply?.data) {

--- a/src/widgets/ui/MusicInfo/index.tsx
+++ b/src/widgets/ui/MusicInfo/index.tsx
@@ -4,10 +4,10 @@ import { useNavigate } from 'react-router-dom';
 
 import { MoreButton } from 'pages/detail/ui/MoreButton';
 
-import { DeleteReviewModal } from 'widgets/ui/PlayList/DeleteReviewModal';
 
 import { BoardDetail } from 'entities/community/model/types';
 import { useDeleteReplyMutation, useMyRepliesQuery } from 'entities/reply/api/reply.queries';
+import { DeleteReplyModal } from 'entities/reply/ui/DeleteReplyModal';
 
 import { ROUTES } from 'shared/config/routes';
 import { Button, StarRatingInput } from 'shared/ui/';
@@ -103,7 +103,7 @@ export const MusicInfo = ({
           </TagBlock>
         </MusicInfoBox>
       </Layout>
-      <DeleteReviewModal
+      <DeleteReplyModal
         open={open}
         hasReview={hasReview}
         onClose={() => setOpen(false)}

--- a/src/widgets/ui/MusicInfo/index.tsx
+++ b/src/widgets/ui/MusicInfo/index.tsx
@@ -134,7 +134,7 @@ const ToolTip = styled.div`
   opacity: 0;
   position: absolute;
   left: 0;
-  transform: translate(0, -100%);
+  transform: translate(0, -20%);
   padding: 16px 20px 18px 20px;
   border-radius: 6px;
   border: 1px solid ${({ theme }) => theme.colors[400]};
@@ -143,6 +143,7 @@ const ToolTip = styled.div`
   color: ${({ theme }) => theme.colors.white};
   ${({ theme }) => theme.fonts.wantedSans.B6};
   white-space: nowrap;
+  pointer-events: none;
 `;
 
 const AdminConfirm = styled.div`

--- a/src/widgets/ui/PlayList/DeleteReviewModal.tsx
+++ b/src/widgets/ui/PlayList/DeleteReviewModal.tsx
@@ -4,31 +4,15 @@ export const DeleteReviewModal = ({
   open,
   onClose,
   onConfirm,
-  hasReview,
+  text = `정말 플레이리스트를 
+              삭제하시겠어요?`,
+  confirmText = '삭제하기',
 }: {
   open: boolean;
   onClose: () => void;
   onConfirm: () => void;
-  hasReview: boolean;
+  text?: string;
+  confirmText?: string;
 }) => {
-  if (hasReview) {
-    return (
-      <ConfirmModal
-        text="작성한 리뷰가 없습니다."
-        confirmText="확인"
-        open={open}
-        onClose={onClose}
-        onConfirm={onClose}
-      />
-    );
-  }
-  return (
-    <ConfirmModal
-      text="정말 리뷰를 삭제 하시겠어요?"
-      confirmText="삭제하기"
-      open={open}
-      onClose={onClose}
-      onConfirm={onConfirm}
-    />
-  );
+  return <ConfirmModal text={text} confirmText={confirmText} open={open} onClose={onClose} onConfirm={onConfirm} />;
 };


### PR DESCRIPTION
- 기존 관리자 승인 툴팁이 헤더에 가려저있어 좀 더 아래로 위치를 조정했습니다.
     - 제목이 최소한으로 가려지는 방향으로 두었습니다.

> 수정 전
> ![image](https://github.com/user-attachments/assets/c8ade034-4d6e-400b-88f6-88792dcf9ba7)
> 
> 수정 후
> ![image](https://github.com/user-attachments/assets/e888ec87-04ab-4fb1-bfa8-631d1c2eadaa)

- 추가로 이전에는 보이지 않는 툴팁에 마우스를 드래그해도 창이 활성화되었는데, 관리자 승인에 드래그했을 때만 뜨도록 수정했습니다.