### PR TITLE
곡 제목, 아티스트명에 텍스트만 들어가도록, 엔터키는 띄워쓰기로 교체되도록 수정

### DIFF
--- a/src/features/createPost/ui/CreateForm/EditableElement.tsx
+++ b/src/features/createPost/ui/CreateForm/EditableElement.tsx
@@ -12,6 +12,13 @@ export const EditableElement = forwardRef<HTMLSpanElement, EditableElementProps>
     onChange(value);
   };
 
+  const handlePaste = (event: React.ClipboardEvent<HTMLSpanElement>) => {
+    event.preventDefault();
+    let text = event.clipboardData.getData('text/plain');
+    text = text.replace(/[\r\n]+/g, ' ');
+    document.execCommand('insertText', false, text);
+  };
+
   return (
     <StyledEditableElement
       ref={ref}
@@ -19,6 +26,7 @@ export const EditableElement = forwardRef<HTMLSpanElement, EditableElementProps>
       role="textbox"
       contentEditable
       onInput={handleInput}
+      onPaste={handlePaste}
       data-placeholder={placeholder}
     />
   );


### PR DESCRIPTION
- 해당 항목란에 이미지가 들어가는 경우가 있어 텍스트만 입력받도록 수정했습니다.

> 해당 예시 사진입니다.
> ![image](https://github.com/user-attachments/assets/28dc7f56-05ff-489e-a85f-7949710b3207)

- 엔터키가 적용된 텍스트를 복붙한 뒤 전체 드래그 후 삭제하면 text칸이 사라지는 버그를 발견했습니다.
  - 해당 문제과 더불어 엔터가 필요하지는 않을 것 같기에 엔터를 ' '로 replace하도록 수정하였습니다.