### PR TITLE
관리자가 아니여도 공지사항의 작성 버튼이 노출되던 부분 수정

### DIFF
--- a/src/pages/notice/ui/Notice.tsx
+++ b/src/pages/notice/ui/Notice.tsx
@@ -6,6 +6,7 @@ import { noticeSearchFilterOptions } from 'pages/admin/config/searchFilterOption
 import { notice } from 'entities/notice/api/notice.query';
 
 import { ROUTES } from 'shared/config/routes';
+import { useUserInfoStore } from 'shared/store/userInfo';
 import { Button, Pagination, SearchInputWithFilter, Table } from 'shared/ui';
 
 import {
@@ -37,6 +38,9 @@ export const NoticePage = () => {
   const content = data?.content || [];
   const totalPages = data?.totalPages || 1; // 전체 페이지 수
 
+  const { userInfo } = useUserInfoStore();
+  const isAdmin = userInfo.authority === 'ADMIN'; // 예시: 관리자만 작성 가능
+
   const tableData = content.map(({ id, title, username, createdAt }) => {
     return {
       title: (
@@ -58,9 +62,11 @@ export const NoticePage = () => {
       <BoardContainer>
         <Header>
           <H1>공지사항</H1>
-          <Button width={132} variant="primaryOutline">
-            작성
-          </Button>
+          {isAdmin && (
+            <Button width={132} variant="primaryOutline">
+              작성
+            </Button>
+          )}
         </Header>
         <TableContainer>
           <Table head={tableHead} data={tableData} isLoading={isLoading} />


### PR DESCRIPTION
- 로그인하지 않은 상태, 일반 회원으로 로그인을 한뒤 공지사항 리스트 접근 시 우상단 작성 버튼이 활성화 되어있는 부분을 수정했습니다.

> ![image](https://github.com/user-attachments/assets/b0fc7c1d-8288-43a8-9c87-91a13802d2dd)
