### PR TITLE
플레이리스트 관련 추가 데이터 연결 및 UI 수정

### DIFF
--- a/src/widgets/ui/NavBar/PlayList/ShowAllPlayListButton/index.tsx
+++ b/src/widgets/ui/NavBar/PlayList/ShowAllPlayListButton/index.tsx
@@ -1,0 +1,34 @@
+import { useNavigate } from 'react-router-dom';
+
+import { ROUTES } from 'shared/config/routes';
+
+import { ShowAllPlayListButton as StyledButton } from '../styled';
+
+interface ShowAllPlayListButtonProps {
+  openIndexes: number[];
+  playLists: Array<{
+    youtubePlaylistId: string;
+  }>;
+}
+
+export const ShowAllPlayListButton = ({ openIndexes, playLists }: ShowAllPlayListButtonProps) => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    // 현재 펼쳐진 플레이리스트가 있는 경우 해당 플레이리스트의 상세 페이지로 이동
+    if (openIndexes.length > 0 && playLists) {
+      const openIndex = openIndexes[0]; // 현재는 하나만 열릴 수 있으므로 첫 번째 요소
+      const openPlaylist = playLists[openIndex];
+      navigate(`${ROUTES.PLAYLIST}`, {
+        state: {
+          id: openPlaylist.youtubePlaylistId,
+        },
+      });
+    } else {
+      // 펼쳐진 플레이리스트가 없는 경우 일반 플레이리스트 페이지로 이동
+      navigate(ROUTES.PLAYLIST);
+    }
+  };
+
+  return <StyledButton onClick={handleClick}>플레이리스트 전체 보기</StyledButton>;
+}; 

--- a/src/widgets/ui/NavBar/PlayList/TrackList/TrackItem/index.tsx
+++ b/src/widgets/ui/NavBar/PlayList/TrackList/TrackItem/index.tsx
@@ -8,7 +8,8 @@ import { ArtistName, TrackInfo, TrackInfoContainer } from './styled';
 
 export interface TrackItemType {
   albumName: string;
-  genres: string[] | null;
+  artists: Array<{ id: number; name: string }> | null;
+  genres: Array<{ id: number; genreName: string }> | null;
   name: string;
   playtime: string | null;
   songLink: string;
@@ -28,8 +29,15 @@ export const TrackItem = ({ size, list }: TrackItemProps) => {
         </CoverWrapper>
         {size === 'large' && (
           <TrackInfo>
-            <Title>{list.albumName}</Title>
-            <ArtistName>{list.name} </ArtistName>
+            <Title>{list.name}</Title>
+            <ArtistName>
+              {list.artists && list.artists.map((artist, index) => (
+                <span key={artist.id}>
+                  {artist.name}
+                  {index < list.artists!.length - 1 ? ', ' : ''}
+                </span>
+              ))}
+            </ArtistName>
           </TrackInfo>
         )}
       </TrackInfoContainer>

--- a/src/widgets/ui/NavBar/PlayList/TrackList/index.tsx
+++ b/src/widgets/ui/NavBar/PlayList/TrackList/index.tsx
@@ -1,6 +1,6 @@
 import { NavBarSizeProps } from 'widgets/ui/NavBar/type';
 
-import { Track, TrackListContainer, TrackListScrollableContainer } from './styled';
+import { Track, TrackListContainer, TrackListScrollableContainer, NoMusicText } from './styled';
 import { TrackItem } from './TrackItem';
 
 export interface TrackItemType {
@@ -22,11 +22,15 @@ export const TrackList = ({ size, open, playListId, listAll }: TrackListProps) =
   return (
     <TrackListContainer size={size} open={open} playListId={playListId} listAll={listAll}>
       <TrackListScrollableContainer>
-        {listAll.map((item, idx) => (
-          <Track key={idx} size={size}>
-            <TrackItem size={size} list={item} />
-          </Track>
-        ))}
+        {listAll.length > 0 ? (
+          listAll.map((item, idx) => (
+            <Track key={idx} size={size}>
+              <TrackItem size={size} list={item} />
+            </Track>
+          ))
+        ) : (
+          <NoMusicText>저장된 음악이 없습니다.</NoMusicText>
+        )}
       </TrackListScrollableContainer>
     </TrackListContainer>
   );

--- a/src/widgets/ui/NavBar/PlayList/TrackList/styled.ts
+++ b/src/widgets/ui/NavBar/PlayList/TrackList/styled.ts
@@ -70,3 +70,13 @@ export const Track = styled.div<NavBarSizeProps>`
       justify-content: center;
     `};
 `;
+
+export const NoMusicText = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 60px;
+  color: ${({ theme }) => theme.colors[200]};
+  ${({ theme }) => theme.fonts.wantedSans.B6};
+  text-align: center;
+`;

--- a/src/widgets/ui/NavBar/PlayList/index.tsx
+++ b/src/widgets/ui/NavBar/PlayList/index.tsx
@@ -41,7 +41,14 @@ export const PlayList = ({ size }: NavBarSizeProps) => {
   const [errorMessage, setErrorMessage] = useState(''); // 에러 메시지
 
   const toggleTrackList = (index: number) => {
-    setOpenIndexes((prev) => (prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index]));
+    setOpenIndexes((prev) => {
+      // 이미 열려있는 플레이리스트를 클릭한 경우 닫기
+      if (prev.includes(index)) {
+        return prev.filter((i) => i !== index);
+      }
+      // 다른 플레이리스트를 클릭한 경우 기존 것을 닫고 새로운 것만 열기
+      return [index];
+    });
   };
 
   const handleDeleteReview = () => {

--- a/src/widgets/ui/NavBar/PlayList/index.tsx
+++ b/src/widgets/ui/NavBar/PlayList/index.tsx
@@ -15,7 +15,8 @@ import { MoreButton } from 'shared/ui/MoreButton';
 import { Spinner } from 'shared/ui/Spinner';
 
 import { PlayListItem } from './PlayListItem';
-import { PlayListContainer, PlayListFoldButton, ShowAllPlayListButton } from './styled';
+import { ShowAllPlayListButton } from './ShowAllPlayListButton';
+import { PlayListContainer, PlayListFoldButton } from './styled';
 import { TrackList } from './TrackList';
 
 interface PlayList {
@@ -112,7 +113,7 @@ export const PlayList = ({ size }: NavBarSizeProps) => {
           <PlayListFoldButton onClick={() => setOpenIndexes([])}>
             <IconFold width={18} height={18} />
           </PlayListFoldButton>
-          <ShowAllPlayListButton>플레이리스트 전체 보기</ShowAllPlayListButton>
+          <ShowAllPlayListButton openIndexes={openIndexes} playLists={data?.playLists || []} />
         </>
       )}
 

--- a/src/widgets/ui/PlayList/PlayListMusicList.tsx
+++ b/src/widgets/ui/PlayList/PlayListMusicList.tsx
@@ -17,7 +17,8 @@ export interface Video {
   albumName: string;
   songLink: string;
   thumbNailLink: string;
-  genres: string[] | null;
+  artists: Array<{ id: number; name: string }> | null;
+  genres: Array<{ id: number; genreName: string }> | null;
 }
 
 export interface VideoProps {
@@ -107,11 +108,20 @@ export const PlayListMusicList = ({ videoList, modify, setVideoList, setDeleteVi
           <PlayListInfoBlock>
             <PlayListInfoImg src={item.thumbNailLink} />
             <PlayListInfo>
-              <PlayListInfoTitle>{item.albumName}</PlayListInfoTitle>
-              <PlayListInfoName>{item.name}</PlayListInfoName>
-              {/* <TagBlock>
-                <Tag>K-POP</Tag> <Tag>귀여운</Tag>
-              </TagBlock> */}
+              <PlayListInfoTitle>{item.name}</PlayListInfoTitle>
+              <PlayListInfoName>
+                {item.artists && item.artists.map((artist, index) => (
+                  <span key={artist.id}>
+                    {artist.name}
+                    {index < item.artists!.length - 1 ? ', ' : ''}
+                  </span>
+                ))}
+              </PlayListInfoName>
+              <TagBlock>
+                {item.genres && item.genres.map((genre, genreIndex) => (
+                  <Tag key={genreIndex}>{genre.genreName}</Tag>
+                ))}
+              </TagBlock>
             </PlayListInfo>
           </PlayListInfoBlock>
         </PlayListItem>
@@ -276,22 +286,22 @@ const PlayListInfoName = styled.div`
   max-width: 400px;
 `;
 
-// const TagBlock = styled.div`
-//   display: flex;
-//   align-items: center;
-//   gap: 12px;
-//   flex-wrap: wrap;
-//   position: absolute;
-//   left: 0px;
-//   bottom: 8px;
-//   height: 33px;
-//   width: 300px;
-// `;
+const TagBlock = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  position: absolute;
+  left: 0px;
+  bottom: 8px;
+  height: 33px;
+  width: 300px;
+`;
 
-// const Tag = styled.div`
-//   padding: 6px 10px 7px 10px;
-//   border-radius: 4px;
-//   background: ${({ theme }) => theme.colors[400]};
-//   color: ${({ theme }) => theme.colors[200]};
-//   ${({ theme }) => theme.fonts.wantedSans.B6};
-// `;
+const Tag = styled.div`
+  padding: 6px 10px 7px 10px;
+  border-radius: 4px;
+  background: ${({ theme }) => theme.colors[400]};
+  color: ${({ theme }) => theme.colors[200]};
+  ${({ theme }) => theme.fonts.wantedSans.B6};
+`;


### PR DESCRIPTION
- 플레이리스트 내에 음악 정보가 없을 경우 텍스트가 노출되도록 수정
- 사이드 플레이리스트 확장 시 다른 확장된 플레이리스트가 닫히도록 수정
- 플레이리스트 전체보기 클릭 시 확장된 플레이리스트의 상세 페이지로 이동하도록 수정

> 상단 예시(화질 낮음)
> ![2025-07-05 10-03-25](https://github.com/user-attachments/assets/c1e35bce-f433-40b5-9fa9-91be49702628)
> 

- 플레이리스트에 있는 음악 정보 누락된 데이터 추가 연결
  - 사이드 플레이리스트에서 가수명(플레이리스트 연동 시 가수명이 없던 이유로 제외했었는데 너무 어색하여 다시 반영 및 추가 설명 텍스트 추가 예정)
  - 플레이리스트 상세페이지에서 가수명 및 장르 및 분위기 태크 연결 추가
  

> ![image](https://github.com/user-attachments/assets/6cc1360a-2000-48a6-82c5-cf4b14906f10)
