### PR TITLE
플레이리스트 상세페이지에서 삭제 시 불 필요 api호출 제거 및 메인으로 리다이렉트

### DIFF
--- a/src/features/playlist/lib/usePostPlayListRemoveQuery.ts
+++ b/src/features/playlist/lib/usePostPlayListRemoveQuery.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { fetchPostRemove } from 'entities/playlist/api/PlayListRemove';
+
 import { ROUTES } from 'shared/config/routes';
 
 type RemoveParams = {

--- a/src/features/playlist/lib/usePostPlayListRemoveQuery.ts
+++ b/src/features/playlist/lib/usePostPlayListRemoveQuery.ts
@@ -1,13 +1,24 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { fetchPostRemove } from 'entities/playlist/api/PlayListRemove';
+import { ROUTES } from 'shared/config/routes';
+
+type RemoveParams = {
+  playlistId: string;
+  shouldNavigate?: boolean;
+  navigate?: (to: string) => void;
+}
 
 export const usePlayListRemovePostMutation = () => {
   const queryClient = useQueryClient();
 
   const PlayListRemoveMutation = useMutation({
-    mutationFn: ({ playlistId }: { playlistId: string }) => fetchPostRemove(playlistId),
-    onSuccess: async () => {
+    mutationFn: ({ playlistId }: RemoveParams) => fetchPostRemove(playlistId),
+    onSuccess: async (_data, variables) => {
+      if (variables.shouldNavigate && variables.navigate) {
+        alert('플레이리스트가 삭제되었습니다.');
+        variables.navigate(ROUTES.HOME);
+      }
       await queryClient.invalidateQueries();
     },
   });

--- a/src/shared/config/urls.ts
+++ b/src/shared/config/urls.ts
@@ -32,6 +32,8 @@ const URL = {
     NOTICE_DETAIL: 'musing/notice', // 공지사항 상세 페이지
     NOTICE_SEARCH: 'musing/notice/list/search',
     BOARD_RECOMMEND: 'musing/board/recommend',
+    REPORT_BOARD: 'musing/report/board',
+    REPORT_REPLY: 'musing/report/reply',
 
     // 회원정보
     MEMBERINFO: {
@@ -57,6 +59,8 @@ const URL = {
       REJECT_BOARD: 'musing/admin/board/non/permit', // 게시글 승인 거절
       REMOVED_BOARD_LIST: 'musing/admin/board/list/removed', // 삭제된 게시글 리스트
       REMOVED_BOARD_DETAIL: 'musing/admin/board/removed', // 삭제된 게시글 상세
+      REPORT_REPLY_LIST: 'musing/admin/report/reply/list', // 신고된 댓글 리스트
+      REPORT_BOARD_LIST: 'musing/admin/report/board/list', // 신고된 게시글 리스트
     },
 
     // 플레이리스트
@@ -70,6 +74,7 @@ const URL = {
       ADD: 'musing/playlist/addMusicToPlaylist',
       REMOVE: 'musing/playlist/remove',
       MODIFY: 'musing/playlist/modify',
+      SYNC: 'musing/playlist/sync', //플레이리스트 갱신
     },
 
     TOKENREISSUE: 'musing/auth/reissue', //토큰 재발급

--- a/src/widgets/ui/NavBar/PlayList/index.tsx
+++ b/src/widgets/ui/NavBar/PlayList/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import TempCoverSrc from 'widgets/ui/NavBar/cover.png';
 import { NavBarSizeProps } from 'widgets/ui/NavBar/type';
@@ -33,6 +34,7 @@ export const PlayList = ({ size }: NavBarSizeProps) => {
   const { data: dataAll } = useGetPlayListAllQuery(isLogin());
 
   const removeMutation = usePlayListRemovePostMutation();
+  const navigate = useNavigate();
 
   const [openIndexes, setOpenIndexes] = useState<number[]>([]);
   const [open, setOpen] = useState(false); // 삭제 모달 오픈 상태
@@ -56,10 +58,9 @@ export const PlayList = ({ size }: NavBarSizeProps) => {
     if (!targetPlaylistId || removeMutation.isPending) return;
 
     removeMutation.mutate(
-      { playlistId: targetPlaylistId },
+      { playlistId: targetPlaylistId, shouldNavigate: false, navigate },
       {
         onSuccess: () => {
-          alert('플레이리스트가 삭제되었습니다.');
           setOpen(false);
         },
         onError: () => {

--- a/src/widgets/ui/PlayList/PlayListMusicInfo.tsx
+++ b/src/widgets/ui/PlayList/PlayListMusicInfo.tsx
@@ -1,6 +1,8 @@
 // import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { usePlayListRemovePostMutation } from 'features/playlist/lib/usePostPlayListRemoveQuery';
 
 // import IconHeart from 'shared/assets/image/icons/icon-heart.svg?react';
 import IconTooltip from 'shared/assets/image/icons/icon-tooltip.svg?react';
@@ -32,6 +34,8 @@ export const PlayListMusicInfo = ({ representative, modify, setModify, onRefresh
   const [modifyRep, setModifyRep] = useState(representative);
   // const isLiked = false;
   // const color = isLiked ? theme.colors.primary1 : theme.colors[200];
+  const removeMutation = usePlayListRemovePostMutation();
+  const navigate = useNavigate();
 
   return (
     <>
@@ -122,7 +126,26 @@ export const PlayListMusicInfo = ({ representative, modify, setModify, onRefresh
               >
                 삭제
               </EditAction>
-              <DeleteReviewModal open={open} onClose={() => setOpen(false)} onConfirm={() => {}} />
+              <DeleteReviewModal
+                open={open}
+                onClose={() => setOpen(false)}
+                onConfirm={() => {
+                  if (removeMutation.isPending) return;
+                  removeMutation.mutate(
+                    { playlistId: representative.youtubePlaylistId, shouldNavigate: true, navigate },
+                    {
+                      onSuccess: () => {
+                        setOpen(false);
+                        alert('플레이리스트가 삭제되었습니다.');
+                      },
+                      onError: () => {
+                        alert('플레이리스트 삭제 중 오류가 발생했습니다.');
+                        setOpen(false);
+                      },
+                    },
+                  );
+                }}
+              />
             </AdminEdit>
           </AdminBlock>
         ) : (

--- a/src/widgets/ui/PlayList/PlayListMusicInfo.tsx
+++ b/src/widgets/ui/PlayList/PlayListMusicInfo.tsx
@@ -2,6 +2,7 @@
 import styled from '@emotion/styled';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+
 import { usePlayListRemovePostMutation } from 'features/playlist/lib/usePostPlayListRemoveQuery';
 
 // import IconHeart from 'shared/assets/image/icons/icon-heart.svg?react';


### PR DESCRIPTION
- 기존 플레이리스트 상세페이지에서 삭제 시 플레이리스트가 제거되었지만
 빈 플레이리스트 페이지가 유지되며 해당 플리를 select요청을 3번하며 지연되는 문제가 있었습니다.
  - 그래서 조건을 달아서 네비게이션바에서 삭제의 경우 그대로로 냅두며,
  상세페이지에서 삭제 시 메인으로 리다이렉트 되게하여 해당 호출이 없도록 하였습니다.